### PR TITLE
Relicense to `MIT-0 OR (Apache-2.0 WITH LLVM-Exception)`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bevy_alacritty"
 version = "0.1.0"
 edition = "2021"
-license = "Apache-2.0"
+license = "MIT OR (Apache-2.0 WITH LLVM-exception)"
 
 [dependencies]
 alacritty_terminal = "0.24"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -174,3 +174,20 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.

--- a/LICENSE-MIT-0
+++ b/LICENSE-MIT-0
@@ -1,0 +1,14 @@
+MIT No Attribution
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+## License
+
+Unless otherwise specified, all code in this repository is dual-licensed under
+either:
+
+- MIT-0 License ([LICENSE-MIT-0](LICENSE-MIT-0))
+- Apache License, Version 2.0, with LLVM Exceptions
+  ([LICENSE-APACHE](LICENSE-APACHE))
+
+at your option. This means you may select the license you prefer to use.
+
+### Your Contributions
+
+Any contribution intentionally submitted for inclusion in the work by you, as
+defined in the Apache-2.0 license, shall be dual licensed as above, without any
+additional terms or conditions.


### PR DESCRIPTION
This PR relicenses the codebase to the following SPDX license identifier:

`MIT-0 OR (Apache-2.0 WITH LLVM-Exception)`

Note that:
* I used the LLVM-Exception for apache-2.0 (for better GPLv2 compatibility)
* I used MIT-0 instead of MIT, which is strictly more permissive than MIT by removing attribution. This is effectively a public domain compatible license.

@marceline-cramer please confirm that you are the original author of this work and grant your permission to relicense the codebase in accordance with the above SPDX identifier with no additional terms or conditions.
