### PR TITLE
fix SPDX identifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bevy_alacritty"
 version = "0.1.0"
 edition = "2021"
-license = "MIT OR (Apache-2.0 WITH LLVM-exception)"
+license = "MIT-0 OR (Apache-2.0 WITH LLVM-exception)"
 
 [dependencies]
 alacritty_terminal = "0.24"


### PR DESCRIPTION
Hi sorry in #4 I wrote "MIT" instead of "MIT-0" in the cargo.toml. This PR fixes it and reflects the intended license:

`MIT-0 OR (Apache-2.0 WITH LLVM-exception)`